### PR TITLE
Regexp will not match and you will get warnings about undefined values

### DIFF
--- a/lib/Mojolicious/Plugin/GroupedParams.pm
+++ b/lib/Mojolicious/Plugin/GroupedParams.pm
@@ -20,9 +20,10 @@ sub register {
                 my $params = $self->req->params->to_hash;
 
                 for my $key ( keys %$params ) {
-                   my ($group, $name) = $key =~ /^([^.]+)\.(.+)$/;
-                   $groups->{$group} ||= {};
-                   $groups->{$group}{$name} = $params->{$key};            
+                   if ( my ($group, $name) = $key =~ /^([^.]+)\.(.+)$/ ) {
+                       $groups->{$group} ||= {};
+                       $groups->{$group}{$name} = $params->{$key};
+                   }
                 }
 
             } 


### PR DESCRIPTION
Regexp will not match and you will get warnings about undefined values if parameter name does not contain dot. So you should always check that regexp has matched. 
