### PR TITLE
Custom delimiters support

### DIFF
--- a/lib/Mojolicious/Plugin/GroupedParams.pm
+++ b/lib/Mojolicious/Plugin/GroupedParams.pm
@@ -12,7 +12,7 @@ sub register {
 
     my $dms = $conf->{delimiters} || ['.'];
     my $dms_re = join( '|', map { quotemeta($_) } @$dms );
-    my $key_split_re = qr/^([^.]+)(?:$dms_re)(.+)$/;
+    my $key_split_re = qr/^(.+)(?:$dms_re)(.+)$/;
 
     $app->helper(
         grouped_params => sub {


### PR DESCRIPTION
Here is the patch with custom delimiters support.

Plugin can be configured in a next way:

``` perl
$self->plugin( 'grouped_params', {delimiter => [ "-", "."] } )
```
