### PR TITLE
s/render_text\(/render( text

### DIFF
--- a/t/main.t
+++ b/t/main.t
@@ -18,7 +18,7 @@ get '/test' => sub {
     my ( $self ) = @_;
 
     my $p = $self->grouped_params('test');
-    $self->render_text("$p->{key1}, $p->{key2}");    
+    $self->render( text => "$p->{key1}, $p->{key2}" );    
 
 };
 
@@ -29,7 +29,7 @@ get '/test2' => sub {
     my ( $self ) = @_;
 
     my $p = $self->grouped_params('test');
-    $self->render_text("$p->{'splited.key'}");    
+    $self->render( text => "$p->{'splited.key'}" );    
 
 };
 


### PR DESCRIPTION
the method ```render_text``` was removed a long time ago...